### PR TITLE
Fix stretched avatar images

### DIFF
--- a/apps/midgard/src/components/cards/large-user.tsx
+++ b/apps/midgard/src/components/cards/large-user.tsx
@@ -20,7 +20,7 @@ export default function LargeUserCard({
 				<div className='absolute bottom-0 left-0 h-1/2 w-full rounded-t-xl bg-zinc-100'></div>
 				<div className='absolute inset-0 grid place-content-center rounded-full bg-transparent'>
 					{(imageUrl && (
-						<img src={imageUrl} alt={fullName} className='h-36 w-36 rounded-full' />
+						<img src={imageUrl} alt={fullName} className='h-36 w-36 rounded-full object-cover' />
 					)) ?? (
 						<div className='grid h-36 w-36 place-content-center rounded-full bg-gradient-to-br from-primary via-sky-800 to-emerald-800 font-bold text-5xl text-primary-foreground'>
 							<span className='m-0 leading-0 '>{initials}</span>

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -18,7 +18,7 @@ function AvatarImage({ className, ...props }: React.ComponentProps<typeof Avatar
 	return (
 		<AvatarPrimitive.Image
 			data-slot='avatar-image'
-			className={cn("aspect-square size-full", className)}
+			className={cn("aspect-square size-full object-cover", className)}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
Images that are not a 1:1 ratio are being stretched out to fit the container. You could of course resize the images but this serves as a nice fallback option.

Do note I have not been able to test this, since I was unable to run the project locally, and also unable to read the error due to it exiting instantly upon crashing. Instead of spending time figuring out the issue I'm putting my money on this fix working.

It's not a big fix but it bugged me enough to make an MR.

## Before: 
<img width="814" height="469" alt="image" src="https://github.com/user-attachments/assets/b07bcb60-8cba-4c56-b014-fb26bb12a313" />

## After:
<img width="878" height="492" alt="image" src="https://github.com/user-attachments/assets/2beb51a0-a27a-44ee-86f0-17b5842d6fff" />

---

As you can see it's not perfect as the subject would need to be perfectly center but it does the job.