### PR TITLE
Center job listing cards and set max width to 20rem

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"tailwindCSS.experimental.configFile": "packages/ui/src/styles/globals.css"
-}

--- a/apps/midgard/src/app/job-listings/page.tsx
+++ b/apps/midgard/src/app/job-listings/page.tsx
@@ -36,7 +36,7 @@ export default async function JobListingsPage() {
 			<Title className="mx-auto max-w-6xl">Stillingsannonser</Title>
 			<div className="flex w-full max-w-[1300px] flex-col gap-4 sm:mx-auto md:flex-row">
 				<FilterJobListings companies={companies} />
-				<div className="grid w-full min-w-0 grid-cols-1 items-center gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
+				<div className="grid w-full min-w-0 grid-cols-1 justify-items-center gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
 					{jobListings.map((job) => (
 						<JobListingCard
 							listingId={job._id}

--- a/apps/midgard/src/components/home/events-carousel.tsx
+++ b/apps/midgard/src/components/home/events-carousel.tsx
@@ -32,7 +32,7 @@ export default async function EventsCarousel({ className }: Readonly<{ className
 			</Carousel>
 			<Button
 				asChild
-				className="mx-8 bg-emerald-600 py-6 font-semibold text-primary-foreground hover:bg-emerald-700"
+				className="mx-8 bg-emerald-600 py-6 font-semibold text-primary-foreground hover:bg-emerald-700 md:mx-16"
 			>
 				<Link href={"/events"}>Se alle arrangementer</Link>
 			</Button>

--- a/apps/midgard/src/components/job-listings/job-listing-card.tsx
+++ b/apps/midgard/src/components/job-listings/job-listing-card.tsx
@@ -28,7 +28,7 @@ export default function JobListingCard({
 	return (
 		<div
 			key={listingId}
-			className="flex h-[450px] w-full flex-col overflow-clip rounded-lg bg-white shadow-md dark:bg-zinc-800"
+			className="flex h-[450px] w-full max-w-80 flex-col overflow-clip rounded-lg bg-white shadow-md dark:bg-zinc-800"
 		>
 			<div
 				className={`py-4 text-center ${typeColors[type] ?? "bg-gray-400"} font-semibold text-lg text-primary-foreground`}


### PR DESCRIPTION
This pull request primarily includes minor UI improvements to the job listings and events carousel components, as well as a cleanup of VSCode workspace settings. The changes focus on better alignment, consistent styling, and codebase maintenance.

**UI improvements:**

* Added `justify-items-center` to the job listings grid in `JobListingsPage` to center the job listing cards within each grid cell, improving visual alignment.
* Set a `max-w-80` constraint on each `JobListingCard` to ensure consistent card widths and a more uniform appearance.
* Increased horizontal margin (`md:mx-16`) for the "See all events" button in the `EventsCarousel` component, enhancing spacing on medium screens and above.

**Codebase maintenance:**

* Removed the `.vscode/settings.json` file, cleaning up project-specific editor settings.