### PR TITLE
Resolves #135 Add link to student information in navigation menu

### DIFF
--- a/apps/midgard/src/components/common/header.tsx
+++ b/apps/midgard/src/components/common/header.tsx
@@ -183,6 +183,12 @@ function LargeNavigation({ className }: Readonly<{ className?: string }>) {
 							<NavigationMenuContent className="z-10">
 								<div className="grid w-[300px] gap-4">
 									<NavigationMenuLink asChild>
+										<Link href="/students">
+											<div className="font-medium">For studenter</div>
+											<div className="text-muted-foreground">Nyttig informasjon for studenter!</div>
+										</Link>
+									</NavigationMenuLink>
+									<NavigationMenuLink asChild>
 										<Link href="/contact">
 											<div className="font-medium">Si Ifra</div>
 											<div className="text-muted-foreground">


### PR DESCRIPTION
This pull request improves the navigation menu for students by adding a more descriptive and informative link to the "For studenter" section. This change enhances the user experience by providing clearer context about the content available for students.

Navigation menu improvements:

* Added a new `NavigationMenuLink` for the `/students` route, including a title and a helpful description ("Nyttig informasjon for studenter!") to make the section more informative and user-friendly.

*Why no tests*
It's is only navigational change and nothing critical.