### PR TITLE
Resolves #134 - Disable registration 30 minutes after start

### DIFF
--- a/apps/midgard/src/app/events/[slug]/page.tsx
+++ b/apps/midgard/src/app/events/[slug]/page.tsx
@@ -39,7 +39,11 @@ export async function generateMetadata({
 	};
 }
 
-export default async function EventPage({ params }: { params: Promise<{ slug: Id<"events"> }> }) {
+export default async function EventPage({
+	params,
+}: {
+	params: Promise<{ slug: Id<"events"> }>;
+}) {
 	const eventId = (await params).slug;
 
 	const token = await getAuthToken();
@@ -58,7 +62,10 @@ export default async function EventPage({ params }: { params: Promise<{ slug: Id
 		id: event.hostingCompany,
 	});
 
-	const preloadedRegistrations = await preloadQuery(api.registration.getByEventId, { eventId });
+	const preloadedRegistrations = await preloadQuery(
+		api.registration.getByEventId,
+		{ eventId },
+	);
 
 	return (
 		<ResponsiveCenterContainer>
@@ -73,7 +80,10 @@ export default async function EventPage({ params }: { params: Promise<{ slug: Id
 						<h1 className="scroll-m-20 text-balance pb-2 font-bold text-3xl tracking-normal">
 							{event.teaser}
 						</h1>
-						<SanitizeHtml html={event.description} className="prose dark:prose-invert" />
+						<SanitizeHtml
+							html={event.description}
+							className="prose dark:prose-invert"
+						/>
 					</ContainerCard>
 				</main>
 				<aside className="flex flex-col gap-8 md:col-span-2">
@@ -95,14 +105,19 @@ export default async function EventPage({ params }: { params: Promise<{ slug: Id
 							</div>
 						</div>
 						<div className="rounded-b-xl bg-zinc-100 px-8 pb-8 dark:bg-zinc-800">
-							<SanitizeHtml html={company.description} className="prose-lg dark:prose-invert" />
+							<SanitizeHtml
+								html={company.description}
+								className="prose-lg dark:prose-invert"
+							/>
 						</div>
 					</div>
 					<div className="grid grid-cols-1 gap-4">
 						{event.organizers
 							.sort((a, b) => {
-								if (a.role === "hovedansvarlig" && b.role !== "hovedansvarlig") return -1;
-								if (a.role !== "hovedansvarlig" && b.role === "hovedansvarlig") return 1;
+								if (a.role === "hovedansvarlig" && b.role !== "hovedansvarlig")
+									return -1;
+								if (a.role !== "hovedansvarlig" && b.role === "hovedansvarlig")
+									return 1;
 								return 0;
 							})
 							.map((organizer) =>
@@ -134,7 +149,11 @@ export default async function EventPage({ params }: { params: Promise<{ slug: Id
 												asChild
 												className="text-primary-foreground dark:bg-primary-light dark:text-primary"
 											>
-												<a href={`mailto:${organizer.email}`} rel="noopener" target="_blank">
+												<a
+													href={`mailto:${organizer.email}`}
+													rel="noopener"
+													target="_blank"
+												>
 													Ta kontakt
 												</a>
 											</Button>

--- a/apps/midgard/src/components/events/event-metadata.tsx
+++ b/apps/midgard/src/components/events/event-metadata.tsx
@@ -5,7 +5,14 @@ import type { Doc } from "@workspace/backend/convex/dataModel";
 import { Button } from "@workspace/ui/components/button";
 import { type Preloaded, usePreloadedQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
-import { CalendarDays, Globe, IdCard, MapPin, Users, Utensils } from "lucide-react";
+import {
+	CalendarDays,
+	Globe,
+	IdCard,
+	MapPin,
+	Users,
+	Utensils,
+} from "lucide-react";
 import { humanReadableDateTime } from "@/utils/dateFormatting";
 import QRCode from "./registration/qr-code";
 import RegistrationButton from "./registration/registration-button";
@@ -21,7 +28,8 @@ export function EventMetadata({
 	const event = usePreloadedQuery(preloadedEvent);
 	const registrations = usePreloadedQuery(preloadedRegistrations);
 
-	const availableSpots = event.participationLimit - (registrations.registered.length || 0);
+	const availableSpots =
+		event.participationLimit - (registrations.registered.length || 0);
 
 	return (
 		<div>
@@ -37,7 +45,8 @@ export function EventMetadata({
 					<Utensils className="size-6 min-w-6 md:size-8" /> {event.food}
 				</p>
 				<p className="flex items-center gap-2 font-semibold md:text-lg">
-					<Users className="size-6 min-w-6 md:size-8" /> {`${availableSpots} plasser igjen`}
+					<Users className="size-6 min-w-6 md:size-8" />{" "}
+					{`${availableSpots} plasser igjen`}
 				</p>
 				<p className="flex items-center gap-2 font-semibold md:text-lg">
 					<Globe className="size-6 min-w-6 md:size-8" /> {event.language}
@@ -68,7 +77,8 @@ export function EventActionButton({
 	event: Doc<"events">;
 	registrations: FunctionReturnType<typeof api.registration.getByEventId>;
 }>) {
-	const availableSpots = event.participationLimit - (registrations.registered.length || 0);
+	const availableSpots =
+		event.participationLimit - (registrations.registered.length || 0);
 
 	if (event.externalUrl && event.externalUrl.length > 0) {
 		return (
@@ -90,16 +100,20 @@ export function EventActionButton({
 				type="button"
 				className="min-h-fit w-3/4 whitespace-normal text-balance rounded-xl bg-zinc-500 text-lg text-primary-foreground hover:cursor-pointer hover:bg-zinc-500 sm:py-6 md:py-8 dark:bg-zinc-700"
 			>
-				Påmelding åpner {humanReadableDateTime(new Date(event.registrationOpens))}
+				Påmelding åpner{" "}
+				{humanReadableDateTime(new Date(event.registrationOpens))}
 			</Button>
 		);
 	}
+
+	const HALF_HOUR = 30 * 60 * 1000;
+	const disabledButtons = Date.now() - event.eventStart >= HALF_HOUR;
 
 	return (
 		<RegistrationButton
 			registration={registrations}
 			availableSpots={availableSpots}
-			editRegistrationDisabled={Date.now() - event.eventStart >= 60 * 60 * 1000}
+			disabled={disabledButtons}
 			event={event}
 		/>
 	);

--- a/apps/midgard/src/components/events/registration/register-form.tsx
+++ b/apps/midgard/src/components/events/registration/register-form.tsx
@@ -38,11 +38,13 @@ export default function RegisterForm({
 	eventId,
 	className,
 	waitlist,
+	disabled,
 }: Readonly<{
 	className?: string;
 	eventId: Id<"events">;
 	userId: Id<"users">;
 	waitlist: boolean;
+	disabled: boolean;
 }>) {
 	const [open, setOpen] = useState(false);
 	const postHog = usePostHog();
@@ -76,7 +78,12 @@ export default function RegisterForm({
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
-				<Button className={className} type="button" onClick={() => setOpen(true)}>
+				<Button
+					className={className}
+					type="button"
+					onClick={() => setOpen(true)}
+					disabled={disabled}
+				>
 					{waitlist ? "Det er fullt! Meld deg på venteliste" : "Meld deg på"}
 				</Button>
 			</DialogTrigger>
@@ -84,11 +91,12 @@ export default function RegisterForm({
 				<DialogHeader>
 					<DialogTitle>Meld meg på</DialogTitle>
 					<DialogDescription className="">
-						Meld deg på bedriftspresentasjonen! Dersom du har noen algerier eller andre ting vi
-						burde vite om, ber vi deg vennligst oppi dem nå.{" "}
+						Meld deg på bedriftspresentasjonen! Dersom du har noen algerier
+						eller andre ting vi burde vite om, ber vi deg vennligst oppi dem nå.{" "}
 						<span className="font-bold">
-							NB! Dersom du melder deg på sent, eller blir flyttet fra ventelisten sent, så er det
-							ikke sikker at vi kan ta hensyn til allergener.
+							NB! Dersom du melder deg på sent, eller blir flyttet fra
+							ventelisten sent, så er det ikke sikker at vi kan ta hensyn til
+							allergener.
 						</span>
 					</DialogDescription>
 				</DialogHeader>
@@ -101,7 +109,9 @@ export default function RegisterForm({
 								<FormItem>
 									<FormLabel>Allergier eller andre merknader</FormLabel>
 									<Input {...field} />
-									<FormDescription>Har du noen allergier, eller andre merknader?</FormDescription>
+									<FormDescription>
+										Har du noen allergier, eller andre merknader?
+									</FormDescription>
 									<FormMessage />
 								</FormItem>
 							)}

--- a/apps/midgard/src/components/events/registration/registration-button.tsx
+++ b/apps/midgard/src/components/events/registration/registration-button.tsx
@@ -13,23 +13,27 @@ import RegisterForm from "./register-form";
 export default function RegistrationButton({
 	registration,
 	availableSpots,
-	editRegistrationDisabled,
+	disabled,
 	event,
 }: Readonly<{
 	registration: FunctionReturnType<typeof api.registration.getByEventId>;
 	availableSpots: number;
-	editRegistrationDisabled: boolean;
+	disabled: boolean;
 	event: Doc<"events">;
 }>) {
 	const path = usePathname();
 
 	const { isAuthenticated } = useConvexAuth();
-	const currentUser = useQuery(api.users.current, isAuthenticated ? undefined : "skip");
+	const currentUser = useQuery(
+		api.users.current,
+		isAuthenticated ? undefined : "skip",
+	);
 	const currentUsersPoints = useQuery(
 		api.points.getCurrentStudentsPoints,
 		isAuthenticated ? undefined : "skip",
 	);
-	const numberOfPoints = currentUsersPoints?.reduce((acc, curr) => acc + curr.severity, 0) || 0;
+	const numberOfPoints =
+		currentUsersPoints?.reduce((acc, curr) => acc + curr.severity, 0) || 0;
 
 	const currentUsersRegistration = registration.registered.find(
 		(registration) => registration.userId === currentUser?._id,
@@ -50,7 +54,11 @@ export default function RegistrationButton({
 		);
 	}
 
-	if (numberOfPoints >= 3 && !currentUsersRegistration && !currentUsersWaitlistRegistration) {
+	if (
+		numberOfPoints >= 3 &&
+		!currentUsersRegistration &&
+		!currentUsersWaitlistRegistration
+	) {
 		return (
 			<Button
 				type="button"
@@ -68,19 +76,21 @@ export default function RegistrationButton({
 				eventId={event._id}
 				userId={currentUser._id}
 				className={`w-3/4 whitespace-normal text-balance rounded-xl bg-emerald-600 px-6 py-8 text-center font-semibold text-lg text-primary-foreground hover:cursor-pointer hover:bg-emerald-700 md:w-1/2`}
+				disabled={disabled}
 				waitlist={availableSpots === 0}
 			/>
 		);
 	}
 
-	const registrationToEdit = currentUsersRegistration ?? currentUsersWaitlistRegistration;
+	const registrationToEdit =
+		currentUsersRegistration ?? currentUsersWaitlistRegistration;
 
 	if (!registrationToEdit) return null;
 
 	return (
 		<EditRegistration
 			registration={registrationToEdit}
-			disabled={editRegistrationDisabled}
+			disabled={disabled}
 			event={event}
 		/>
 	);

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,58 +1,58 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@workspace/ui/lib/utils"
+import { cn } from "@workspace/ui/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:brightness-70 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	{
+		variants: {
+			variant: {
+				default: "bg-primary text-primary-foreground hover:bg-primary/90",
+				destructive:
+					"bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+				outline:
+					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+				secondary:
+					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
+				ghost:
+					"hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+			size: {
+				default: "h-9 px-4 py-2 has-[>svg]:px-3",
+				sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+				lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+				icon: "size-9",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	},
+);
 
 function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
+	className,
+	variant,
+	size,
+	asChild = false,
+	...props
 }: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
-  const Comp = asChild ? Slot : "button"
+	VariantProps<typeof buttonVariants> & {
+		asChild?: boolean;
+	}) {
+	const Comp = asChild ? Slot : "button";
 
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  )
+	return (
+		<Comp
+			data-slot="button"
+			className={cn(buttonVariants({ variant, size, className }))}
+			{...props}
+		/>
+	);
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };


### PR DESCRIPTION
Rename editRegistrationDisabled to disabled and propagate it through RegistrationButton, RegisterForm and EditRegistration. Use a HALF_HOUR (30 minutes) cutoff to disable action buttons after the event starts. Also apply minor formatting/import tweaks and adjust Button disabled styling for consistent appearance.

## Why no test
Tested manually, since the testing suite is not up and running yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated registration deadline: The registration button now closes 30 minutes after an event starts (previously 60 minutes).

* **Style**
  * Code formatting and readability improvements across event components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->