### PR TITLE
164/joblisting-webhook

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -9,9 +9,8 @@ CLERK_FRONTEND_API_URL=https://...
 ## Resend enviornment variables
 RESEND_API_KEY=re_...
 
-## Job Listing Webhook configuration
-# URL to send webhook notifications when a job listing is published
-# This can be a Discord webhook, Slack webhook, or any custom webhook endpoint
-# Example Discord: https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN
-# Example Slack: https://hooks.slack.com/services/YOUR/WEBHOOK/URL
-JOB_LISTING_WEBHOOK_URL=https://your-discord-or-slack-webhook-url
+## Slack integration
+# Slack webhook URL for job listing notifications
+# Incoming Webhooks still work - create one in your Slack App settings
+# Get this from: https://api.slack.com/apps → Your App → Incoming Webhooks
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -11,6 +11,7 @@ RESEND_API_KEY=re_...
 
 ## Job Listing Webhook configuration
 # URL to send webhook notifications when a job listing is published
+# This can be a Discord webhook, Slack webhook, or any custom webhook endpoint
+# Example Discord: https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN
+# Example Slack: https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 JOB_LISTING_WEBHOOK_URL=https://your-discord-or-slack-webhook-url
-# Secret for authenticating incoming webhook requests to /job-listings-webhook
-JOB_LISTING_WEBHOOK_SECRET=your-secret-key-here

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -8,3 +8,9 @@ CLERK_FRONTEND_API_URL=https://...
 
 ## Resend enviornment variables
 RESEND_API_KEY=re_...
+
+## Job Listing Webhook configuration
+# URL to send webhook notifications when a job listing is published
+JOB_LISTING_WEBHOOK_URL=https://your-discord-or-slack-webhook-url
+# Secret for authenticating incoming webhook requests to /job-listings-webhook
+JOB_LISTING_WEBHOOK_SECRET=your-secret-key-here

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -39,6 +39,56 @@ http.route({
 	}),
 });
 
+http.route({
+	path: "/job-listings-webhook",
+	method: "POST",
+	handler: httpAction(async (ctx, request) => {
+		const webhookSecret = process.env.JOB_LISTING_WEBHOOK_SECRET;
+
+		if (!webhookSecret) {
+			console.error("JOB_LISTING_WEBHOOK_SECRET is not configured");
+			return new Response("Webhook not configured", { status: 500 });
+		}
+
+		// Verify the webhook secret from the Authorization header
+		const authHeader = request.headers.get("authorization");
+		const expectedAuth = `Bearer ${webhookSecret}`;
+
+		if (authHeader !== expectedAuth) {
+			console.error("Invalid webhook secret");
+			return new Response("Unauthorized", { status: 401 });
+		}
+
+		try {
+			const payload = await request.json();
+			const { listingId, webhookUrl } = payload;
+
+			if (!listingId || !webhookUrl) {
+				return new Response("Missing required fields: listingId, webhookUrl", {
+					status: 400,
+				});
+			}
+
+			// Trigger the webhook notification
+			await ctx.runMutation(internal.listings.notifyJobListingPublished, {
+				listingId,
+				webhookUrl,
+			});
+
+			return new Response(
+				JSON.stringify({ success: true, listingId }),
+				{
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		} catch (error) {
+			console.error("Error processing job listing webhook:", error);
+			return new Response("Internal server error", { status: 500 });
+		}
+	}),
+});
+
 async function validateRequest(req: Request): Promise<WebhookEvent | null> {
 	const payloadString = await req.text();
 	const svixId = req.headers.get("svix-id");


### PR DESCRIPTION
Webhook for posting JOB listings to the Navet Slack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job listings now automatically send Slack notifications when published. When a new listing is created and published, or when a previously unpublished listing becomes active, a formatted notification is delivered to your configured Slack workspace to keep teams informed of new opportunities.
  * Slack integration is optional and automatically skips if not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->