### PR TITLE
Refactor registration page and use Readonly types

### DIFF
--- a/apps/bifrost/src/app/layout.tsx
+++ b/apps/bifrost/src/app/layout.tsx
@@ -65,7 +65,9 @@ export default function RootLayout({
 	);
 }
 
-async function AuthorizedContent({ children }: { children: React.ReactNode }) {
+async function AuthorizedContent({
+	children,
+}: Readonly<{ children: React.ReactNode }>) {
 	const hasRights = await hasBasicRights();
 
 	if (!hasRights) {

--- a/apps/midgard/src/app/error.tsx
+++ b/apps/midgard/src/app/error.tsx
@@ -94,7 +94,7 @@ export default function GlobalError({
 							className="text-muted-foreground text-sm italic"
 							href="mailto:web@ifinavet.no"
 						>
-							Send oss en mail
+							Send oss en mail!
 						</a>
 					</div>
 				</div>

--- a/apps/midgard/src/app/globals.css
+++ b/apps/midgard/src/app/globals.css
@@ -11,9 +11,3 @@
 	--primary: var(--color-gray-800);
 	--background: oklch(0.2169 0 0);
 }
-
-/*
-* {
-	outline: 1px solid #f00 !important;
-}
-*/


### PR DESCRIPTION
Replace preloadQuery with fetchQuery for event lookup, extract registration status rendering into RegistrationStatusHandler, tighten props types with Readonly, and remove debug outline in globals.css.

Testing Vercel rights.