### PR TITLE
feat: style expired arrangements differently

### DIFF
--- a/apps/midgard/src/components/events/event-card.tsx
+++ b/apps/midgard/src/components/events/event-card.tsx
@@ -14,6 +14,10 @@ export type EventCardType = {
 export default function EventCard({
 	event,
 }: Readonly<{ event: EventCardType }>) {
+
+	const isExpired =
+		event.eventDate ? event.eventDate < new Date() : false;
+
 	return (
 		<div className="flex h-100 flex-col overflow-clip rounded-lg border border-primary/10 shadow-md">
 			<div className="relative grid h-32 place-content-center px-8 py-6 md:h-48 lg:h-52 dark:bg-white/95">
@@ -25,18 +29,31 @@ export default function EventCard({
 					fill
 				/>
 			</div>
-			<div className="flex flex-1 flex-col justify-between gap-4 bg-primary p-6 text-primary-foreground dark:bg-gray-800">
+
+			<div
+				className={`flex flex-1 flex-col justify-between gap-4 p-6 ${
+		isExpired
+			? "bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-white"
+			: "bg-primary text-primary-foreground dark:bg-gray-800"
+	}`}
+			>
 				<div className="flex flex-col gap-4">
-					<h2 className="font-bold text-xl tracking-tight">{event.title}</h2>
-					<p className="line-clamp-2 whitespace-normal">{event.teaser}</p>
+					<h2 className="font-bold text-xl tracking-tight">
+						{event.title}
+					</h2>
+					<p className="line-clamp-2 whitespace-normal">
+						{event.teaser}
+					</p>
 				</div>
+
 				{!!(event.eventDate && event.participationLimit) && (
 					<div className="flex flex-col justify-center gap-4 sm:flex-row">
 						<p className="flex gap-2">
 							<Users /> {event.participationLimit}
 						</p>
 						<p className="flex gap-2">
-							<CalendarDays /> {humanReadableDate(event.eventDate)}
+							<CalendarDays />{" "}
+							{humanReadableDate(event.eventDate)}
 						</p>
 					</div>
 				)}

--- a/apps/midgard/src/components/events/event-card.tsx
+++ b/apps/midgard/src/components/events/event-card.tsx
@@ -15,8 +15,17 @@ export default function EventCard({
 	event,
 }: Readonly<{ event: EventCardType }>) {
 
-	const isExpired =
-		event.eventDate ? event.eventDate < new Date() : false;
+	const isExpired = (() => {
+		if (!event.eventDate) return false;
+
+		const today = new Date();
+		today.setHours(0, 0, 0, 0);
+
+		const eventDate = new Date(event.eventDate);
+		eventDate.setHours(0, 0, 0, 0);
+
+		return eventDate < today;
+	})();
 
 	return (
 		<div className="flex h-100 flex-col overflow-clip rounded-lg border border-primary/10 shadow-md">
@@ -32,10 +41,10 @@ export default function EventCard({
 
 			<div
 				className={`flex flex-1 flex-col justify-between gap-4 p-6 ${
-		isExpired
-			? "bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-white"
-			: "bg-primary text-primary-foreground dark:bg-gray-800"
-	}`}
+					isExpired
+						? "bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-white"
+						: "bg-primary text-primary-foreground dark:bg-gray-800"
+				}`}
 			>
 				<div className="flex flex-col gap-4">
 					<h2 className="font-bold text-xl tracking-tight">


### PR DESCRIPTION
📝 Description

This PR updates the styling of expired arrangements to make them visually distinct from ongoing or upcoming events.
An arrangement is considered expired if its eventDate is earlier than the current date. When expired, the event card now displays a grey background with adjusted text colors for better contrast and clarity in both light and dark modes.
This improves the overall user experience and makes the interface more intuitive.

🔗 Related Issue

Closes #181

🎯 Type of Change
 🎨 Style/UI update (changes that don't affect functionality)
 ✨ Enhancement

💭 Additional Notes
No backend logic was modified.
Only conditional styling was added in event-card.tsx.
The change maintains proper dark mode support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated event card styling to visually distinguish expired events with a gray background and adjusted text color, making it easier to identify inactive items at a glance.
  * Minor formatting tweaks to event title/teaser rendering and spacing adjustment before the displayed date for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->