### PR TITLE
feat: add color indicator to job type select

### DIFF
--- a/apps/bifrost/src/components/job-listings/job-listings-form/job-listing-form.tsx
+++ b/apps/bifrost/src/components/job-listings/job-listings-form/job-listing-form.tsx
@@ -2,7 +2,7 @@
 
 import { useForm } from "@tanstack/react-form";
 import { api } from "@workspace/backend/convex/api";
-import type { JOB_TYPES } from "@workspace/shared/constants";
+import { JOB_TYPES, LISTING_COLORS } from "@workspace/shared/constants";
 import { Button } from "@workspace/ui/components/button";
 import {
 	Command,
@@ -50,6 +50,23 @@ import ContactsSection from "./contacts-section";
 type FormMeta = {
 	submitAction: "primary" | "secondary" | "tertiary";
 };
+
+type JobType = (typeof JOB_TYPES)[number];
+
+function JobTypeLabel({ type }: Readonly<{ type: JobType }>) {
+	return (
+		<>
+			<span
+				aria-hidden="true"
+				className={cn(
+					"size-4 rounded-full",
+					LISTING_COLORS[type] ?? "bg-gray-400",
+				)}
+			/>
+			{type}
+		</>
+	);
+}
 
 export default function JobListingForm({
 	onPrimarySubmitAction,
@@ -149,13 +166,13 @@ export default function JobListingForm({
 											>
 												{companyValue
 													? companies?.find(
-															(company) => company.name === companyValue,
-														)?.name
+														(company) => company.name === companyValue,
+													)?.name
 													: "Velg en bedrift..."}
 												<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
 											</Button>
 										</PopoverTrigger>
-										<PopoverContent className="w-[200px] p-0" align="start">
+										<PopoverContent className="w-50 p-0" align="start">
 											<Command>
 												<CommandInput placeholder="Søk etter bedrift..." />
 												<CommandList>
@@ -228,13 +245,18 @@ export default function JobListingForm({
 										value={field.state.value}
 									>
 										<SelectTrigger>
-											<SelectValue placeholder="Velg type" />
+											<SelectValue placeholder="Velg type">
+												{field.state.value ? (
+													<JobTypeLabel type={field.state.value} />
+												) : null}
+											</SelectValue>
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Fulltid">Fulltid</SelectItem>
-											<SelectItem value="Deltid">Deltid</SelectItem>
-											<SelectItem value="Internship">Internship</SelectItem>
-											<SelectItem value="Sommerjobb">Sommerjobb</SelectItem>
+											{JOB_TYPES.map((type) => (
+												<SelectItem key={type} textValue={type} value={type}>
+													<JobTypeLabel type={type} />
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 									{isInvalid && <FieldError errors={field.state.meta.errors} />}

--- a/apps/midgard/src/components/job-listings/job-listing-card.tsx
+++ b/apps/midgard/src/components/job-listings/job-listing-card.tsx
@@ -1,4 +1,5 @@
 import type { Id } from "@workspace/backend/convex/dataModel";
+import { LISTING_COLORS } from "@workspace/shared/constants";
 import { Button } from "@workspace/ui/components/button";
 import Image from "next/image";
 import Link from "next/link";
@@ -18,12 +19,6 @@ export default function JobListingCard({
 	title: string;
 	teaser: string;
 }>) {
-	const typeColors: Record<string, string> = {
-		Sommerjobb: "bg-orange-400",
-		Fulltid: "bg-indigo-400",
-		Deltid: "bg-emerald-400",
-		Internship: "bg-fuchsia-400",
-	};
 
 	return (
 		<div
@@ -31,7 +26,7 @@ export default function JobListingCard({
 			className="flex h-[450px] w-full max-w-80 flex-col overflow-clip rounded-lg bg-white shadow-md dark:bg-zinc-800"
 		>
 			<div
-				className={`py-4 text-center ${typeColors[type] ?? "bg-gray-400"} font-semibold text-lg text-primary-foreground`}
+				className={`py-4 text-center ${LISTING_COLORS[type] ?? "bg-gray-400"} font-semibold text-lg text-primary-foreground`}
 			>
 				{type}
 			</div>

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -3,3 +3,4 @@ export { DEGREE_TYPES } from "./degrees";
 export { JOB_TYPES } from "./job_types";
 export type { ORGANIZER_ROLE } from "./organizer_roles";
 export { STUDY_PROGRAMS } from "./programs";
+export { LISTING_COLORS } from "./listing_colors";

--- a/packages/shared/constants/listing_colors.ts
+++ b/packages/shared/constants/listing_colors.ts
@@ -1,0 +1,6 @@
+export const LISTING_COLORS: Record<string, string> = {
+    Sommerjobb: "bg-orange-400",
+    Fulltid: "bg-indigo-400",
+    Deltid: "bg-emerald-400",
+    Internship: "bg-fuchsia-400",
+};


### PR DESCRIPTION
<img width="514" height="231" alt="Untitled" src="https://github.com/user-attachments/assets/617f09dc-a6b3-4091-8920-5a88e71535b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job listing types now display color-coded visual indicators consistently throughout the application. Both the job listing form and individual job cards now feature these color-coded labels, providing improved visual clarity and making it easier to identify and distinguish different job types at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->