### PR TITLE
Make PostHog, Sentry and Resend optional

### DIFF
--- a/apps/bifrost/sentry.edge.config.ts
+++ b/apps/bifrost/sentry.edge.config.ts
@@ -5,15 +5,23 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-	dsn: "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072",
+const dsn =
+	process.env.SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072"
+		: undefined);
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
+if (dsn) {
+	Sentry.init({
+		dsn,
 
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
 
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
+
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}

--- a/apps/bifrost/sentry.server.config.ts
+++ b/apps/bifrost/sentry.server.config.ts
@@ -4,15 +4,23 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-	dsn: "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072",
+const dsn =
+	process.env.SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072"
+		: undefined);
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
+if (dsn) {
+	Sentry.init({
+		dsn,
 
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
 
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
+
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}

--- a/apps/bifrost/src/instrumentation-client.ts
+++ b/apps/bifrost/src/instrumentation-client.ts
@@ -1,26 +1,34 @@
 import * as Sentry from "@sentry/nextjs";
 import posthog from "posthog-js";
 
-if (!process.env.NEXT_PUBLIC_POSTHOG_KEY || !process.env.NEXT_PUBLIC_POSTHOG_HOST) {
-	throw new Error("PostHog environment variables are not set");
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+const sentryDsn =
+	process.env.NEXT_PUBLIC_SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072"
+		: undefined);
+
+if (posthogKey && posthogHost) {
+	posthog.init(posthogKey, {
+		api_host: "/relay-aXgZ",
+		ui_host: "https://eu.posthog.com",
+		defaults: "2025-05-24",
+	});
 }
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-	api_host: "/relay-aXgZ",
-	ui_host: "https://eu.posthog.com",
-	defaults: "2025-05-24",
-});
+if (sentryDsn) {
+	Sentry.init({
+		dsn: sentryDsn,
 
-Sentry.init({
-	dsn: "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072",
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
-
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/hugin/sentry.edge.config.ts
+++ b/apps/hugin/sentry.edge.config.ts
@@ -5,15 +5,23 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-	dsn: "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072",
+const dsn =
+	process.env.SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072"
+		: undefined);
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
+if (dsn) {
+	Sentry.init({
+		dsn,
 
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
 
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
+
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}

--- a/apps/hugin/sentry.server.config.ts
+++ b/apps/hugin/sentry.server.config.ts
@@ -4,15 +4,23 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-	dsn: "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072",
+const dsn =
+	process.env.SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072"
+		: undefined);
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
+if (dsn) {
+	Sentry.init({
+		dsn,
 
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
 
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
+
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}

--- a/apps/hugin/src/instrumentation-client.ts
+++ b/apps/hugin/src/instrumentation-client.ts
@@ -1,15 +1,23 @@
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-	dsn: "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072",
+const sentryDsn =
+	process.env.NEXT_PUBLIC_SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://04d7959e133fb993cec8d4f62d3418ef@o4509833113501696.ingest.de.sentry.io/4509835991253072"
+		: undefined);
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
+if (sentryDsn) {
+	Sentry.init({
+		dsn: sentryDsn,
 
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
+
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/hugin/src/providers/posthog-provider.tsx
+++ b/apps/hugin/src/providers/posthog-provider.tsx
@@ -10,7 +10,11 @@ export default function PostHogProvider({
 	children: React.ReactNode;
 }>) {
 	useEffect(() => {
-		posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+		const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+		const host = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+		if (!key || !host) return;
+
+		posthog.init(key, {
 			api_host: "/relay-aXgZ",
 			ui_host: "https://eu.posthog.com",
 			defaults: "2025-05-24",

--- a/apps/midgard/sentry.edge.config.ts
+++ b/apps/midgard/sentry.edge.config.ts
@@ -5,15 +5,23 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-	dsn: "https://97690ed14bdf1b094f610bcfcaef3a6b@o4509833113501696.ingest.de.sentry.io/4509833115336784",
+const dsn =
+	process.env.SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://97690ed14bdf1b094f610bcfcaef3a6b@o4509833113501696.ingest.de.sentry.io/4509833115336784"
+		: undefined);
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
+if (dsn) {
+	Sentry.init({
+		dsn,
 
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
 
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
+
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}

--- a/apps/midgard/sentry.server.config.ts
+++ b/apps/midgard/sentry.server.config.ts
@@ -4,15 +4,23 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-	dsn: "https://97690ed14bdf1b094f610bcfcaef3a6b@o4509833113501696.ingest.de.sentry.io/4509833115336784",
+const dsn =
+	process.env.SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://97690ed14bdf1b094f610bcfcaef3a6b@o4509833113501696.ingest.de.sentry.io/4509833115336784"
+		: undefined);
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
+if (dsn) {
+	Sentry.init({
+		dsn,
 
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
 
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
+
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}

--- a/apps/midgard/src/instrumentation-client.ts
+++ b/apps/midgard/src/instrumentation-client.ts
@@ -2,27 +2,35 @@ import * as Sentry from "@sentry/nextjs";
 import posthog from "posthog-js";
 import { cookieConsentGiven } from "./components/common/consent";
 
-if (!process.env.NEXT_PUBLIC_POSTHOG_KEY || !process.env.NEXT_PUBLIC_POSTHOG_HOST) {
-	throw new Error("PostHog environment variables are not set");
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+const sentryDsn =
+	process.env.NEXT_PUBLIC_SENTRY_DSN?.trim() ||
+	(process.env.NODE_ENV === "production"
+		? "https://97690ed14bdf1b094f610bcfcaef3a6b@o4509833113501696.ingest.de.sentry.io/4509833115336784"
+		: undefined);
+
+if (posthogKey && posthogHost) {
+	posthog.init(posthogKey, {
+		api_host: "/relay-aXgZ",
+		ui_host: "https://eu.posthog.com",
+		defaults: "2025-05-24",
+		persistence: cookieConsentGiven() === "yes" ? "localStorage+cookie" : "memory",
+	});
 }
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-	api_host: "/relay-aXgZ",
-	ui_host: "https://eu.posthog.com",
-	defaults: "2025-05-24",
-	persistence: cookieConsentGiven() === "yes" ? "localStorage+cookie" : "memory",
-});
+if (sentryDsn) {
+	Sentry.init({
+		dsn: sentryDsn,
 
-Sentry.init({
-	dsn: "https://97690ed14bdf1b094f610bcfcaef3a6b@o4509833113501696.ingest.de.sentry.io/4509833115336784",
+		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+		tracesSampleRate: 1,
+		// Enable logs to be sent to Sentry
+		enableLogs: true,
 
-	// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-	tracesSampleRate: 1,
-	// Enable logs to be sent to Sentry
-	enableLogs: true,
-
-	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
-});
+		// Setting this option to true will print useful information to the console while you're setting up Sentry.
+		debug: false,
+	});
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/packages/backend/convex/emails.ts
+++ b/packages/backend/convex/emails.ts
@@ -1,6 +1,6 @@
 "use node";
 
-import { Resend } from "@convex-dev/resend";
+import { Resend, type SendEmailOptions } from "@convex-dev/resend";
 import { pretty, render } from "@react-email/render";
 import AvailableSeatEmail from "@workspace/emails/available-seat-email";
 import FreeForAllEmail from "@workspace/emails/free-for-all-email";
@@ -8,14 +8,23 @@ import LockedOutEmail from "@workspace/emails/locked-out-email";
 import PointsEmail from "@workspace/emails/point-email";
 import { v } from "convex/values";
 import { components } from "./_generated/api";
-import { internalAction } from "./_generated/server";
+import { type ActionCtx, internalAction } from "./_generated/server";
 
 /**
  * Configures the Resend client used by backend email actions.
  */
 export const resend: Resend = new Resend(components.resend, {
-	testMode: false,
+	testMode: process.env.RESEND_TEST_MODE === "true",
 });
+
+async function deliver(ctx: ActionCtx, options: SendEmailOptions): Promise<void> {
+	if (process.env.LOCAL_DEVELOPMENT === "true") {
+		console.info(`Skipped email "${options.subject}" on a local development deployment`);
+		return;
+	}
+
+	await resend.sendEmail(ctx, options);
+}
 
 /**
  * Sends the email informing a participant that they received points.
@@ -42,7 +51,7 @@ export const sendGottenPointsEmail = internalAction({
 			),
 		);
 
-		await resend.sendEmail(ctx, {
+		await deliver(ctx, {
 			from: "Navet <prikker@ifinavet.no>",
 			replyTo: ["arrangement@ifinavet.no"],
 			to: participantEmail,
@@ -66,7 +75,7 @@ export const sendTooManyPointsEmail = internalAction({
 	handler: async (ctx, { participantEmail }) => {
 		const html = await pretty(await render(LockedOutEmail()));
 
-		await resend.sendEmail(ctx, {
+		await deliver(ctx, {
 			from: "Navet <prikker@ifinavet.no>",
 			replyTo: ["arrangement@ifinavet.no"],
 			to: participantEmail,
@@ -105,7 +114,7 @@ export const sendAvailableSeatEmail = internalAction({
 			),
 		);
 
-		await resend.sendEmail(ctx, {
+		await deliver(ctx, {
 			from: "Navet <info@ifinavet.no>",
 			replyTo: ["arrangement@ifinavet.no"],
 			to: participantEmail,
@@ -145,7 +154,7 @@ export const sendFreeForAll = internalAction({
 			),
 		);
 
-		await resend.sendEmail(ctx, {
+		await deliver(ctx, {
 			from: "Navet <info@ifinavet.no>",
 			replyTo: ["arrangement@ifinavet.no"],
 			to: participantEmail,


### PR DESCRIPTION
A fresh clone threw on startup when NEXT_PUBLIC_POSTHOG_KEY was missing, and the Sentry DSN was hardcoded so local development reported errors straight into the production project. Both are now opt-in. Sentry keeps the current DSN as a production fallback, so deployments are unaffected and nothing needs to be configured before merging.

Emails are logged instead of sent when the deployment is marked as local, which lets email flows be developed without a Resend account. Production is unchanged: it sends as before, and a missing Resend key still fails loudly rather than silently dropping mail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability by allowing monitoring and analytics services to remain disabled when configuration is missing.
  - Prevented missing analytics settings from causing runtime errors.
  - Preserved consent-based analytics behavior.

- **New Features**
  - Added environment-based configuration for monitoring and analytics services, with production-only fallback behavior.
  - Added local-development safeguards to prevent test emails from being delivered.
  - Added configurable email test mode for safer verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->