### PR TITLE
refactor: consolidate waitlist logic into events/waitlist module

### DIFF
--- a/packages/backend/convex/events/mutations.ts
+++ b/packages/backend/convex/events/mutations.ts
@@ -1,9 +1,9 @@
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { Id } from "../_generated/dataModel";
-import { internalMutation, mutation, MutationCtx } from "../_generated/server";
+import { internalMutation, mutation } from "../_generated/server";
 import { getCurrentUserOrThrow } from "../auth/currentUser";
-import { makeStatusPending } from "./registrations/mutations";
+import { updateWaitlist } from "./waitlist/mutations";
 
 // Shared validator for organizer roles
 const organizerRoleValidator = v.union(v.literal("hovedansvarlig"), v.literal("medhjelper"));
@@ -189,59 +189,6 @@ export const upsertEventOrganizer = internalMutation({
         await Promise.all([...organizersToRemove, ...organizersToAdd, ...organizersToUpdate]);
     },
 });
-
-/**
- * Advances the event waitlist by a given number of places.
- *
- * @param {Id<"events">} eventId - The id of the event to update.
- * @param {number} numOfNewPlaces - The number of new places to offer.
- *
- * @returns {Promise<void>} - Resolves when the waitlist has been processed.
- */
-export const updateWaitlistMutation = internalMutation({
-    args: {
-        eventId: v.id("events"),
-        numOfNewPlaces: v.number(),
-    },
-    handler: async (ctx, { eventId, numOfNewPlaces }) => {
-        await updateWaitlist(ctx, eventId, numOfNewPlaces);
-    },
-});
-
-/**
- * Promotes waitlisted registrations into pending status.
- *
- * @param {MutationCtx} ctx - The Convex mutation context.
- * @param {Id<"events">} eventId - The id of the event to update.
- * @param {number} numOfNewPlaces - The number of new places to offer.
- *
- * @throws - An error if the event cannot be found.
- * @returns {Promise<void>} - Resolves when the waitlist has been updated.
- */
-export const updateWaitlist = async (
-    ctx: MutationCtx,
-    eventId: Id<"events">,
-    numOfNewPlaces: number,
-) => {
-    const waitlistRegistrations = await ctx.db
-        .query("registrations")
-        .withIndex("by_eventIdStatusAndRegistrationTime", (q) =>
-            q.eq("eventId", eventId).eq("status", "waitlist"),
-        )
-        .order("asc")
-        .collect();
-
-    const event = await ctx.db.get(eventId);
-    if (!event) {
-        throw new Error(`Event not for eventId: ${eventId}`);
-    }
-
-    await Promise.all(
-        waitlistRegistrations
-            .slice(0, numOfNewPlaces)
-            .map(async (registration) => await makeStatusPending(ctx, registration, event)),
-    );
-};
 
 /**
  * Updates the published status for multiple events.

--- a/packages/backend/convex/events/registrations/mutations.ts
+++ b/packages/backend/convex/events/registrations/mutations.ts
@@ -1,8 +1,8 @@
 import { v } from "convex/values";
 import { internal } from "../../_generated/api";
-import { Doc } from "../../_generated/dataModel";
-import { mutation, MutationCtx } from "../../_generated/server";
+import { mutation } from "../../_generated/server";
 import { getCurrentUserOrThrow } from "../../auth/currentUser";
+import { makeStatusPending } from "../waitlist/mutations";
 
 /**
  * Accepts a pending registration for the current user.
@@ -245,38 +245,3 @@ export const unregister = mutation({
         return returnData;
     },
 });
-
-/**
- * Moves a registration to pending status and schedules the seat notification email.
- *
- * @param {MutationCtx} ctx - The Convex mutation context.
- * @param {Doc<"registrations">} registrationToMakePending - The registration to update.
- * @param {Doc<"events">} event - The event the registration belongs to.
- *
- * @throws - An error if the user for the registration cannot be resolved.
- * @returns {Promise<void>} - Resolves when the registration has been updated and the email scheduled.
- */
-export const makeStatusPending = async (
-    ctx: MutationCtx,
-    registrationToMakePending: Doc<"registrations">,
-    event: Doc<"events">,
-) => {
-    const user = await ctx.db.get(registrationToMakePending.userId);
-    if (!user) {
-        throw new Error(
-            `Bruker med ID ${registrationToMakePending.userId} ikke funnet. Kan ikke oppdatere registrering.`,
-        );
-    }
-
-    await ctx.db.patch(registrationToMakePending._id, {
-        status: "pending",
-        registrationTime: Date.now(),
-    });
-
-    await ctx.scheduler.runAfter(0, internal.emails.sendAvailableSeatEmail, {
-        participantEmail: user.email,
-        eventTitle: event.title,
-        eventId: event._id,
-        registrationId: registrationToMakePending._id,
-    });
-};

--- a/packages/backend/convex/events/waitlist/mutations.ts
+++ b/packages/backend/convex/events/waitlist/mutations.ts
@@ -1,7 +1,95 @@
 import { v } from "convex/values";
 import { internal } from "../../_generated/api";
-import { internalMutation } from "../../_generated/server";
-import { makeStatusPending } from "../registrations/mutations";
+import { Doc, Id } from "../../_generated/dataModel";
+import { internalMutation, MutationCtx } from "../../_generated/server";
+
+/**
+ * Moves a registration to pending status and schedules the seat notification email.
+ *
+ * @param {MutationCtx} ctx - The Convex mutation context.
+ * @param {Doc<"registrations">} registrationToMakePending - The registration to update.
+ * @param {Doc<"events">} event - The event the registration belongs to.
+ *
+ * @throws - An error if the user for the registration cannot be resolved.
+ * @returns {Promise<void>} - Resolves when the registration has been updated and the email scheduled.
+ */
+export const makeStatusPending = async (
+    ctx: MutationCtx,
+    registrationToMakePending: Doc<"registrations">,
+    event: Doc<"events">,
+) => {
+    const user = await ctx.db.get(registrationToMakePending.userId);
+    if (!user) {
+        throw new Error(
+            `Bruker med ID ${registrationToMakePending.userId} ikke funnet. Kan ikke oppdatere registrering.`,
+        );
+    }
+
+    await ctx.db.patch(registrationToMakePending._id, {
+        status: "pending",
+        registrationTime: Date.now(),
+    });
+
+    await ctx.scheduler.runAfter(0, internal.emails.sendAvailableSeatEmail, {
+        participantEmail: user.email,
+        eventTitle: event.title,
+        eventId: event._id,
+        registrationId: registrationToMakePending._id,
+    });
+};
+
+/**
+ * Advances the event waitlist by a given number of places.
+ *
+ * @param {Id<"events">} eventId - The id of the event to update.
+ * @param {number} numOfNewPlaces - The number of new places to offer.
+ *
+ * @returns {Promise<void>} - Resolves when the waitlist has been processed.
+ */
+export const updateWaitlistMutation = internalMutation({
+    args: {
+        eventId: v.id("events"),
+        numOfNewPlaces: v.number(),
+    },
+    handler: async (ctx, { eventId, numOfNewPlaces }) => {
+        await updateWaitlist(ctx, eventId, numOfNewPlaces);
+    },
+});
+
+/**
+ * Promotes waitlisted registrations into pending status.
+ *
+ * @param {MutationCtx} ctx - The Convex mutation context.
+ * @param {Id<"events">} eventId - The id of the event to update.
+ * @param {number} numOfNewPlaces - The number of new places to offer.
+ *
+ * @throws - An error if the event cannot be found.
+ * @returns {Promise<void>} - Resolves when the waitlist has been updated.
+ */
+export const updateWaitlist = async (
+    ctx: MutationCtx,
+    eventId: Id<"events">,
+    numOfNewPlaces: number,
+) => {
+    const waitlistRegistrations = await ctx.db
+        .query("registrations")
+        .withIndex("by_eventIdStatusAndRegistrationTime", (q) =>
+            q.eq("eventId", eventId).eq("status", "waitlist"),
+        )
+        .order("asc")
+        .collect();
+
+    const event = await ctx.db.get(eventId);
+    if (!event) {
+        throw new Error(`Event not for eventId: ${eventId}`);
+    }
+
+    await Promise.all(
+        waitlistRegistrations
+            .slice(0, numOfNewPlaces)
+            .map(async (registration) => await makeStatusPending(ctx, registration, event)),
+    );
+};
 
 /**
  * Checks pending registrations and reoffers seats when the response window expires.


### PR DESCRIPTION
Maintainability fix

Consolidates the whitelist contract and logic into own component, which creates a necessary abstraction from the raw query and centralizes the whitelisting logic to make it less error-prone. 

CR found some pre-existing issues in the code which will be stacked onto this pr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated waitlist processing into a dedicated waitlist module.
  - Shared registration-status handling is now centralized for more consistent maintenance.
  - Existing event creation, updates, publishing, organizer synchronization, registration handling, and validation behavior remain unchanged.

- **Style**
  - Standardized formatting and indentation across event, registration, and waitlist processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->