### PR TITLE
Feature/allow mailto and tel links in descriptions

### DIFF
--- a/apps/midgard/src/components/common/sanitize-html.tsx
+++ b/apps/midgard/src/components/common/sanitize-html.tsx
@@ -15,7 +15,7 @@ export default function SafeHtml({
 			...sanitizeHtml.defaults.allowedAttributes,
 			img: ["src", "alt", "title", "width", "height", "srcset"],
 		},
-		allowedSchemes: ["http", "https"],
+		allowedSchemes: ["http", "https", "mailto", "tel"],
 		allowedSchemesByTag: {
 			img: ["http", "https", "data"],
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Email and telephone links in displayed HTML now work correctly alongside standard web links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->