### PR TITLE
feat: migrate qr scanner to @yudiel/react-qr-scanner

### DIFF
--- a/apps/bifrost/package.json
+++ b/apps/bifrost/package.json
@@ -30,7 +30,7 @@
     "@workspace/backend": "workspace:*",
     "@workspace/shared": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "@zxing/browser": "^0.1.5",
+    "@yudiel/react-qr-scanner": "^2.6.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/apps/bifrost/src/components/events/registration-scanner/qr-scanner-dialog.tsx
+++ b/apps/bifrost/src/components/events/registration-scanner/qr-scanner-dialog.tsx
@@ -14,13 +14,18 @@ import {
 import { cn } from "@workspace/ui/lib/utils";
 import { useMutation, useQuery } from "convex/react";
 import { QrCode } from "lucide-react";
+import dynamic from "next/dynamic";
 import { usePostHog } from "posthog-js/react";
 import type * as React from "react";
 import { useState } from "react";
 import { toast } from "sonner";
-import QRScanner from "@/components/events/registration-scanner/qr-scanner";
 import { humanReadableDate } from "@/utils/utils";
 import RegisterAttendanceByQr from "./register-by-qr-code";
+
+const QRScanner = dynamic(
+	() => import("@/components/events/registration-scanner/qr-scanner"),
+	{ ssr: false },
+);
 
 export type QRScannerDialogProps = {
 	readonly open?: boolean;

--- a/apps/bifrost/src/components/events/registration-scanner/qr-scanner.tsx
+++ b/apps/bifrost/src/components/events/registration-scanner/qr-scanner.tsx
@@ -1,277 +1,43 @@
 "use client";
 
-import {
-	BrowserMultiFormatReader,
-	type IScannerControls,
-} from "@zxing/browser";
-
-type Result = { getText(): string };
-
-import { Button } from "@workspace/ui/components/button";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@workspace/ui/components/select";
-import {
-	Pause as PauseIcon,
-	Play,
-	QrCode,
-	RefreshCw,
-	Square,
-} from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Scanner, type ScannerErrorKind } from "@yudiel/react-qr-scanner";
 import { toast } from "sonner";
 
-type Cam = { deviceId: string; label: string };
+const ERROR_MESSAGES: Record<ScannerErrorKind, string> = {
+	"permission-denied": "Kameraet mangler tillatelse. Gi tilgang og prøv igjen.",
+	"no-camera": "Fant ingen kamera på denne enheten.",
+	"in-use": "Kameraet er i bruk av en annen app eller fane.",
+	overconstrained: "Kameraet støtter ikke de nødvendige innstillingene.",
+	"insecure-context": "Kameraet krever en sikker tilkobling (HTTPS).",
+	unsupported: "Nettleseren støtter ikke kamerabruk.",
+	aborted: "Kameraet ble avbrutt. Prøv igjen.",
+	security: "Nettleseren blokkerte tilgang til kameraet.",
+	"type-error": "Kunne ikke starte kameraet med disse innstillingene.",
+	unknown: "Kunne ikke starte skanneren.",
+};
 
 export default function QRScannerControlled({
 	onDecodedAction,
 }: Readonly<{
 	onDecodedAction: (text: string) => void;
 }>) {
-	const videoRef = useRef<HTMLVideoElement>(null);
-	const controlsRef = useRef<IScannerControls | null>(null);
-	const streamRef = useRef<MediaStream | null>(null);
-
-	const [cams, setCams] = useState<Cam[]>([]);
-	const [selectedCam, setSelectedCam] = useState<string | undefined>(undefined);
-	const [running, setRunning] = useState(false);
-	const [paused, setPaused] = useState(false);
-	const [snapshot, setSnapshot] = useState<string | null>(null);
-
-	// Enumerate cameras
-	const loadCameras = useCallback(async () => {
-		try {
-			const devices = await navigator.mediaDevices.enumerateDevices();
-			const vids = devices
-				.filter((d) => d.kind === "videoinput")
-				.map((d) => ({ deviceId: d.deviceId, label: d.label || "Camera" }));
-			setCams(vids);
-			if (!selectedCam && vids[0]) setSelectedCam(vids[0].deviceId);
-		} catch {
-			toast.error("Kunne ikke hente kameraer. Krever tillatelse?");
-		}
-	}, [selectedCam]);
-
-	// Start scanning with a specific camera
-	const start = useCallback(async () => {
-		if (!videoRef.current || !selectedCam) return;
-		stop(); // ensure clean state
-
-		setPaused(false);
-
-		const reader = new BrowserMultiFormatReader();
-
-		try {
-			const controls = await reader.decodeFromVideoDevice(
-				selectedCam,
-				videoRef.current,
-				(res?: Result) => {
-					if (res) {
-						const text = res.getText();
-						onDecodedAction(text);
-					}
-				},
-			);
-			controlsRef.current = controls;
-
-			// Grab the active stream from the video element for pause/resume control
-			streamRef.current = (videoRef.current.srcObject as MediaStream) ?? null;
-
-			setRunning(true);
-		} catch (e: unknown) {
-			const message = e instanceof Error ? e.message : "Ukjent feil.";
-			toast.error(`Kunne ikke starte skanneren. ${message}`);
-			stop();
-		}
-	}, [selectedCam]);
-
-	// Stop scanning and release camera
-	const stop = useCallback(() => {
-		controlsRef.current?.stop();
-		controlsRef.current = null;
-
-		if (videoRef.current) {
-			const s = videoRef.current.srcObject as MediaStream | null;
-			if (s) s.getTracks().forEach((t) => t.stop());
-			videoRef.current.srcObject = null;
-		}
-		streamRef.current = null;
-		setRunning(false);
-		setPaused(false);
-		setSnapshot(null);
-	}, []);
-
-	// Pause/resume camera tracks without tearing down the scanner
-	const pause = useCallback(() => {
-		const v = videoRef.current;
-		if (!streamRef.current || !v) return;
-
-		// Capture square snapshot of the current frame
-		const vw = v.videoWidth;
-		const vh = v.videoHeight;
-		if (vw > 0 && vh > 0) {
-			const size = Math.min(vw, vh);
-			const sx = Math.floor((vw - size) / 2);
-			const sy = Math.floor((vh - size) / 2);
-			const canvas = document.createElement("canvas");
-			canvas.width = size;
-			canvas.height = size;
-			const ctx = canvas.getContext("2d");
-			if (ctx) {
-				ctx.drawImage(v, sx, sy, size, size, 0, 0, size, size);
-				try {
-					const url = canvas.toDataURL("image/png");
-					setSnapshot(url);
-				} catch {
-					// ignore
-				}
-			}
-		}
-
-		streamRef.current.getVideoTracks().forEach((t) => {
-			t.enabled = false;
-		});
-		setPaused(true);
-	}, []);
-
-	const resume = useCallback(() => {
-		if (!streamRef.current) return;
-		streamRef.current.getVideoTracks().forEach((t) => {
-			t.enabled = true;
-		});
-		setSnapshot(null);
-		setPaused(false);
-	}, []);
-
-	// Switch camera: stop current, change deviceId, start again
-	const switchCam = useCallback(
-		async (deviceId: string) => {
-			setSelectedCam(deviceId);
-			if (running) {
-				await start(); // will call stop() first
-			}
-		},
-		[running, start],
-	);
-
-	useEffect(() => {
-		(async () => {
-			try {
-				const s = await navigator.mediaDevices.getUserMedia({
-					video: true,
-					audio: false,
-				});
-				s.getTracks().forEach((t) => t.stop());
-			} catch {
-				// ignore; user will be prompted on start()
-			} finally {
-				loadCameras();
-			}
-		})();
-
-		return () => stop();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
 	return (
 		<div className="grid max-w-[480px] gap-2">
-			<div className="relative aspect-square w-full overflow-hidden rounded-lg bg-black">
-				<video
-					ref={videoRef}
-					playsInline
-					className="absolute inset-0 z-0 h-full w-full object-cover"
-					aria-label="QR scanner camera preview"
-					muted
-				>
-					<track kind="captions" src="" label="captions" />
-				</video>
-				{(!running || paused) && (
-					<div className="pointer-events-none absolute inset-0 z-20 grid place-items-center bg-linear-to-br from-muted/40 to-muted/10">
-						<div className="flex flex-col items-center gap-3 text-muted-foreground">
-							<div className="rounded-xl border border-border border-dashed bg-background/60 p-6 shadow-sm">
-								<QrCode className="h-16 w-16" />
-							</div>
-							<div className="text-sm">
-								{paused
-									? "Skanneren er på pause - trykk Forsett for å fortsette"
-									: "Klar - trykk Start for å skanne QR-kode"}
-							</div>
-						</div>
-					</div>
-				)}
-				{paused && snapshot && (
-					<img
-						src={snapshot}
-						alt="Paused snapshot"
-						className="pointer-events-none absolute inset-0 z-10 h-full w-full object-cover"
-					/>
-				)}
-			</div>
-
-			<div className="grid w-full grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center">
-				<Button
-					type="button"
-					size="lg"
-					onClick={running ? stop : start}
-					className="w-full sm:w-auto"
-				>
-					{running ? (
-						<>
-							<Square className="size-4" /> Stopp
-						</>
-					) : (
-						<>
-							<Play className="size-4" /> Start
-						</>
-					)}
-				</Button>
-				<Button
-					type="button"
-					size="lg"
-					onClick={paused ? resume : pause}
-					disabled={!running}
-					variant="outline"
-					className="w-full sm:w-auto"
-				>
-					{paused ? (
-						<>
-							<Play className="size-4" /> Forsett
-						</>
-					) : (
-						<>
-							<PauseIcon className="size-4" /> Pause
-						</>
-					)}
-				</Button>
-				<Select value={selectedCam} onValueChange={switchCam}>
-					<SelectTrigger
-						className="h-11 w-full sm:w-[16rem]"
-						disabled={cams.length <= 1 && running}
-					>
-						<SelectValue placeholder="Velg kamera" />
-					</SelectTrigger>
-					<SelectContent>
-						{cams.map((c, i) => (
-							<SelectItem key={c.deviceId} value={c.deviceId}>
-								{c.label || `Camera ${i + 1}`}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-				<Button
-					type="button"
-					size="icon"
-					onClick={loadCameras}
-					variant="secondary"
-					className="w-full sm:w-auto"
-				>
-					<RefreshCw className="size-4" /> Oppdater
-				</Button>
-			</div>
+			<Scanner
+				formats={["qr_code"]}
+				constraints={{ facingMode: "environment" }}
+				components={{ finder: true, onOff: true }}
+				classNames={{
+					container:
+						"relative aspect-square w-full overflow-hidden rounded-lg bg-black",
+					video: "h-full w-full object-cover",
+				}}
+				onScan={(codes) => {
+					const value = codes[0]?.rawValue;
+					if (value) onDecodedAction(value);
+				}}
+				onError={(error) => toast.error(ERROR_MESSAGES[error.kind])}
+			/>
 		</div>
 	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,9 @@ importers:
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      '@zxing/browser':
-        specifier: ^0.1.5
-        version: 0.1.5(@zxing/library@0.21.3)
+      '@yudiel/react-qr-scanner':
+        specifier: ^2.6.0
+        version: 2.6.0(@types/emscripten@1.41.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4013,6 +4013,9 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/emscripten@1.41.6':
+    resolution: {integrity: sha512-uN+9i8bFT5CUcZfyIEYDrSueACEyKGbUs5kC/72DGlZZoinh84sJfVV0i8UOJD1asdzkvLPBRrKs41kZ8MdEXg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -4154,6 +4157,13 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@yudiel/react-qr-scanner@2.6.0':
+    resolution: {integrity: sha512-WjNcSt7qquYUz1LVbwKzSnRQI47sNrh4Vh6nNiGKVxnYcP+KgN5q9rcSzXyZ/7GRV9PPrnzoIuE5YdOxB9yAog==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8
+
   '@zxing/browser@0.1.5':
     resolution: {integrity: sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==}
     peerDependencies:
@@ -4261,6 +4271,9 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  barcode-detector@3.2.2:
+    resolution: {integrity: sha512-/4QOrrNrCRmDSBWiiP4aC72dnkuXUEdcFRidHgbPRXUpy82XcCMvJssI6fEs6JT42LS7DvBVZO70qasJbYKyrA==}
 
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
@@ -6085,6 +6098,9 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
+
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
@@ -6510,6 +6526,10 @@ packages:
       webpack-cli:
         optional: true
 
+  webrtc-adapter@9.0.6:
+    resolution: {integrity: sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
@@ -6656,6 +6676,11 @@ packages:
         optional: true
       use-sync-external-store:
         optional: true
+
+  zxing-wasm@3.1.3:
+    resolution: {integrity: sha512-3lC9BJk4fR5ZJxcGjb0hVnDFOW7KpLXHIebiBmVd4FDRQZVeObztoTKxRUPxlWwSgxrMRONK0u50hBD1aTYEKg==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -9992,6 +10017,8 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/emscripten@1.41.6': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -10163,6 +10190,15 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@yudiel/react-qr-scanner@2.6.0(@types/emscripten@1.41.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      barcode-detector: 3.2.2(@types/emscripten@1.41.6)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      webrtc-adapter: 9.0.6
+    transitivePeerDependencies:
+      - '@types/emscripten'
+
   '@zxing/browser@0.1.5(@zxing/library@0.21.3)':
     dependencies:
       '@zxing/library': 0.21.3
@@ -10262,6 +10298,12 @@ snapshots:
       hermes-parser: 0.33.3
 
   balanced-match@4.0.4: {}
+
+  barcode-detector@3.2.2(@types/emscripten@1.41.6):
+    dependencies:
+      zxing-wasm: 3.1.3(@types/emscripten@1.41.6)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   base-x@3.0.11:
     dependencies:
@@ -12314,6 +12356,8 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
+  sdp@3.2.2: {}
+
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
@@ -12760,6 +12804,10 @@ snapshots:
       - postcss
       - uglify-js
 
+  webrtc-adapter@9.0.6:
+    dependencies:
+      sdp: 3.2.2
+
   whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@5.0.0: {}
@@ -12873,3 +12921,8 @@ snapshots:
       '@types/react': 19.2.18
       react: 19.2.8
       use-sync-external-store: 1.6.0(react@19.2.8)
+
+  zxing-wasm@3.1.3(@types/emscripten@1.41.6):
+    dependencies:
+      '@types/emscripten': 1.41.6
+      type-fest: 5.8.0


### PR DESCRIPTION
Closes nothing; refs #227 for the missing test runner.

## What was changed

The attendance QR scanner in bifrost is now built on [`@yudiel/react-qr-scanner`](https://github.com/yudielcurbelo/react-qr-scanner) instead of hand rolled camera code on top of `@zxing/browser`. `apps/.../registration-scanner/qr-scanner.tsx` goes from 277 lines to 45.

Removed, because the library covers all of it: device enumeration, the camera dropdown and its refresh button, start/stop, pause/resume via `track.enabled`, the canvas snapshot used to freeze the paused frame, four refs, five pieces of state, and a local `type Result` shim.

Added: the rear camera is selected with `constraints={{ facingMode: "environment" }}`, the ten distinct camera failure kinds map to their own messages instead of one generic toast, and the scanner is loaded with `next/dynamic` so the WebAssembly decoder stays out of the initial bundle of the registrations page. The scan flow itself is unchanged: a decoded code still looks up the registrant and waits for an organiser to register attendance, and the camera keeps running throughout, so this migration is behaviour preserving. Removing the confirmation step is the follow-up PR, not this one.

## Why

Two reasons.

**The wrong camera was selected.** The default was `vids[0]`, whichever device `enumerateDevices()` happened to return first, which has no relationship to which way the camera points. In practice that is the front facing camera, so every scan session started by picking a camera by hand.

Matching device labels for `back`/`rear` is not a fix. iOS exposes several rear lenses — "Back Camera", "Back Dual Wide Camera", "Back Ultra Wide Camera" — in no guaranteed order, and selecting the ultra wide one focuses poorly at the distance a QR code is held. iOS 18 is also [documented to switch between lenses mid stream](https://developer.apple.com/forums/thread/776460) even when `deviceId` is pinned. `facingMode` lets the platform resolve it.

**The dependency was near-dormant.** Measured from the npm and GitHub APIs:

| Package | Weekly downloads | Commits, last 12 months | Last release |
|---|---|---|---|
| `@yudiel/react-qr-scanner` | 232k | 68 | v2.6.0, 2026-05-13 |
| `zxing-wasm` (its decoder) | 1.44M | 100+ | v3.1.3, 2026-08-14 |
| `@zxing/browser` (was in use) | 1.02M | 4 | v0.2.1, 2026-07-06 |
| `html5-qrcode` | 1.42M | 1 | v2.3.8, **2023-04-15** |

Download counts mislead here: `html5-qrcode` is the most starred option and has shipped nothing since April 2023 with 445 open issues. The chain moved to is `@yudiel/react-qr-scanner → barcode-detector → zxing-wasm → zxing-cpp`, so decoding tracks the actively developed C++ implementation rather than the JS port. `@zxing/library`, previously pulled in transitively, is 11.3 MB unpacked across 1892 files.

Note that most attendance scanning happens on iOS, where the browser has no native `BarcodeDetector` at all (Safari 17 keeps it behind a preference and every iOS browser is WebKit), so decoding runs in WebAssembly. The `.wasm` file is fetched from jsDelivr on first use and cached; this is worth knowing if a Content Security Policy is ever added, since it would need whitelisting. The library re-exports `prepareZXingModule` if self hosting becomes preferable.

`formats={["qr_code"]}` is deliberate and load bearing, not an optimisation — with `formats` unset the scanner [silently detects nothing](https://github.com/yudielcurbelo/react-qr-scanner/issues/144).

## How it was tested

- `pnpm --dir apps/bifrost exec tsc --noEmit` — clean; the only output is two pre-existing `.webp` module errors in `src/components/common/sidebar/sidebar.tsx`, which come from `next-env.d.ts` not existing until a first dev or build run and are unrelated to this change.
- `biome lint` clean on the changed files.

**Runtime testing is outstanding and should block merge.** I could not start the app: `next.config.ts` throws without `NEXT_PUBLIC_CONVEX_URL` and I had no Convex or Clerk credentials, so nothing here has decoded a real QR code yet. Before merging this wants a check on a physical iPhone, served over HTTPS since `getUserMedia` is blocked on non-secure origins — confirming the rear camera opens unprompted, that the lens chosen is the standard wide rather than the ultra wide, and that a code from Midgard scans.

Two library behaviours worth a look during that pass: the beep on scan is on by default and [renders as a widget on iOS](https://github.com/yudielcurbelo/react-qr-scanner/issues/131), and `startTimeoutMs` defaults to 3000 ms which has [caused timeouts on slower devices](https://github.com/yudielcurbelo/react-qr-scanner/issues/149).

## Why no tests?

The repository has no test runner configured — no package defines a `test` script and neither Vitest, Jest, Playwright nor `convex-test` is installed anywhere. Filed as #227.

## Notes

No documentation was added at the request of the repository owner, so the `README.md` is untouched despite the documentation requirement in `CONTRIBUTING.md`.

`apps/hugin/package.json` also declares `@zxing/browser` with zero usages in `apps/hugin/src`. Left alone as out of scope, but it can be dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated QR code scanning with a streamlined camera experience.
  - Scanning now focuses on QR codes using the device’s rear-facing camera.
  - Scanning automatically pauses while a registration is being processed.
  - Scanner errors now display Norwegian-language messages.
- **Changes**
  - Removed manual camera selection and camera control options from the scanner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
