### PR TITLE
Fix: Enforce registration-opens time server-side

### DIFF
--- a/apps/midgard/src/components/events/event-metadata.tsx
+++ b/apps/midgard/src/components/events/event-metadata.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type { api } from "@workspace/backend/convex/api";
+import { api } from "@workspace/backend/convex/api";
 import type { Doc } from "@workspace/backend/convex/dataModel";
 import { Button } from "@workspace/ui/components/button";
-import { type Preloaded, usePreloadedQuery } from "convex/react";
+import { type Preloaded, useQuery, usePreloadedQuery } from "convex/react";
 import type { FunctionReturnType } from "convex/server";
 import {
 	CalendarDays,
@@ -13,10 +13,38 @@ import {
 	Users,
 	Utensils,
 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { humanReadableDateTime } from "@/utils/dateFormatting";
 import QRCode from "./registration/qr-code";
 import RegistrationButton from "./registration/registration-button";
 import WaitlistPosition from "./registration/waitlist-position";
+
+/**
+ * Tracks the current time corrected for skew between the device clock and the
+ * Convex server clock, so time-gated UI can't be tricked by changing the
+ * device's system clock.
+ *
+ * @returns {number | undefined} - The clock-skew-corrected timestamp, or undefined until the server time has been fetched.
+ */
+function useServerCorrectedNow() {
+	const serverTime = useQuery(api.events.queries.getServerTime, {});
+	const offsetRef = useRef<number | null>(null);
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		if (serverTime !== undefined && offsetRef.current === null) {
+			offsetRef.current = serverTime - Date.now();
+		}
+	}, [serverTime]);
+
+	useEffect(() => {
+		const interval = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(interval);
+	}, []);
+
+	if (serverTime === undefined) return undefined;
+	return now + (offsetRef.current ?? 0);
+}
 
 export function EventMetadata({
 	preloadedEvent,
@@ -80,6 +108,8 @@ export function EventActionButton({
 	const availableSpots =
 		event.participationLimit - (registrations.registered.length || 0);
 
+	const correctedNow = useServerCorrectedNow();
+
 	if (event.externalUrl && event.externalUrl.length > 0) {
 		return (
 			<Button
@@ -94,11 +124,12 @@ export function EventActionButton({
 		);
 	}
 
-	if (event.registrationOpens > Date.now()) {
+	if (correctedNow === undefined || event.registrationOpens > correctedNow) {
 		return (
 			<Button
 				type="button"
-				className="min-h-fit w-3/4 whitespace-normal text-balance rounded-xl bg-zinc-500 text-lg text-primary-foreground hover:cursor-pointer hover:bg-zinc-500 sm:py-6 md:py-8 dark:bg-zinc-700"
+				disabled
+				className="min-h-fit w-3/4 whitespace-normal text-balance rounded-xl bg-zinc-500 text-lg text-primary-foreground disabled:opacity-100 sm:py-6 md:py-8 dark:bg-zinc-700"
 			>
 				Påmelding åpner{" "}
 				{humanReadableDateTime(new Date(event.registrationOpens))}
@@ -107,7 +138,7 @@ export function EventActionButton({
 	}
 
 	const HALF_HOUR = 30 * 60 * 1000;
-	const disabledButtons = Date.now() - event.eventStart >= HALF_HOUR;
+	const disabledButtons = correctedNow - event.eventStart >= HALF_HOUR;
 
 	return (
 		<RegistrationButton

--- a/packages/backend/convex/events/queries.ts
+++ b/packages/backend/convex/events/queries.ts
@@ -211,6 +211,16 @@ export const getCurrentSemester = query({
 });
 
 /**
+ * Fetches the current server time, used by clients to detect local clock skew.
+ *
+ * @returns {number} - The current server timestamp in milliseconds.
+ */
+export const getServerTime = query({
+	args: {},
+	handler: async () => Date.now(),
+});
+
+/**
  * Fetches an event by id or slug with hosting company and organizer data.
  *
  * @param {string} identifier - Either the event id or event slug.

--- a/packages/backend/convex/events/registrations/mutations.ts
+++ b/packages/backend/convex/events/registrations/mutations.ts
@@ -126,6 +126,12 @@ export const register = mutation({
             throw new Error(`aarangementet med ID ${eventId} ikke funnet.Kan ikke registrere.`);
         }
 
+        if (Date.now() < event.registrationOpens) {
+            throw new Error(
+                `Påmelding til arrangementet "${event.title}" har ikke åpnet ennå.`,
+            );
+        }
+
         const registrations = await ctx.db
             .query("registrations")
             .withIndex("by_eventIdStatusAndRegistrationTime", (q) => q.eq("eventId", eventId))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event registration buttons now use server-synchronized time, providing consistent behavior when a device clock is inaccurate.
  * Registration controls remain safely disabled while the current server time is unavailable.
  * Registrations submitted before the configured opening time are now rejected.

* **Reliability**
  * Registration timing rules are enforced consistently in both the interface and backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->